### PR TITLE
Fix tsbuildinfo ignore entry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,4 +38,4 @@ coverage/
 
 # vite cache
 .cache/
-vite.config.ts.tsbuildinfo
+tsconfig.node.tsbuildinfo


### PR DESCRIPTION
## Summary
- correct tsbuildinfo file ignored by git

## Testing
- `npm run lint` *(fails: couldn't find an eslint configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68436d38b680832babb33dd8fe14df03