### PR TITLE
Add default inventory for new characters

### DIFF
--- a/src/gameServer/itemModel.test.ts
+++ b/src/gameServer/itemModel.test.ts
@@ -4,6 +4,7 @@ import {
   Item,
   createEmptyEquipment,
   createEmptyInventory,
+  createDefaultInventory,
   addItemToInventory,
   equipItemFromInventory,
   unequipItemToInventory
@@ -11,6 +12,11 @@ import {
 import type { Character } from './characterModel';
 
 describe('inventory and equipment system', () => {
+  test('createDefaultInventory returns starter items', () => {
+    const inv = createDefaultInventory();
+    expect(inv.length).toBeGreaterThan(0);
+    expect(inv[0].name).toBe('Épée rouillée');
+  });
   test('equipping moves item from inventory and unequipping returns it', () => {
     const char: Character = {
       id: 1,

--- a/src/gameServer/itemModel.ts
+++ b/src/gameServer/itemModel.ts
@@ -38,6 +38,15 @@ export function createEmptyInventory(): CharacterInventory {
   return [];
 }
 
+// 💾 Liste d'objets de départ pour un nouveau personnage
+export function createDefaultInventory(): CharacterInventory {
+  return [
+    { id: 1, name: 'Épée rouillée', slot: 'mainhand' },
+    { id: 2, name: 'Bouclier en bois', slot: 'offhand' },
+    { id: 3, name: 'Armure en tissu', slot: 'armor' }
+  ];
+}
+
 export function addItemToInventory(inv: CharacterInventory, item: Item, max = MAX_INVENTORY_SIZE): boolean {
   if (inv.length >= max) return false;
   inv.push(item);

--- a/src/services/characterService.test.ts
+++ b/src/services/characterService.test.ts
@@ -32,5 +32,6 @@ describe('characterService', () => {
 
     expect(found).toBeDefined();
     expect(found?.name).toBe('Hero');
+    expect(found?.inventory.length).toBeGreaterThan(0);
   });
 });

--- a/src/services/characterService.ts
+++ b/src/services/characterService.ts
@@ -5,7 +5,8 @@ import {
 } from '../gameServer/characterModel';
 import {
   createEmptyEquipment,
-  createEmptyInventory
+  createEmptyInventory,
+  createDefaultInventory
 } from '../gameServer/itemModel';
 
 const STORAGE_KEY = 'characters';
@@ -75,7 +76,7 @@ export const characterService = {
       name: trimmed,
       stats: createDefaultStats(),
       equipment: createEmptyEquipment(),
-      inventory: createEmptyInventory()
+      inventory: createDefaultInventory()
     };
 
     const current = await characterService.getAll();


### PR DESCRIPTION
## Summary
- provide `createDefaultInventory` with starter gear
- use starter inventory when creating a new character
- test the new function and check inventory on character creation

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68441ad92ad0832ba7aa8d03cf55e24a