### PR TITLE
Add item stat bonuses to equipment

### DIFF
--- a/src/gameServer/itemModel.test.ts
+++ b/src/gameServer/itemModel.test.ts
@@ -40,4 +40,29 @@ describe('inventory and equipment system', () => {
     expect(char.inventory[0]).toEqual(sword);
     expect(char.equipment.mainhand).toBeNull();
   });
+
+  test('item stat bonuses are applied when equipped and removed when unequipped', () => {
+    const char: Character = {
+      id: 1,
+      name: 'Hero',
+      stats: createDefaultStats(),
+      equipment: createEmptyEquipment(),
+      inventory: createEmptyInventory()
+    };
+
+    const sword: Item = {
+      id: 102,
+      name: 'Sword of Power',
+      slot: 'mainhand',
+      bonuses: { stats: { strength: 3 } }
+    };
+
+    addItemToInventory(char.inventory, sword);
+    const base = char.stats.stats.strength;
+    equipItemFromInventory(char, 0);
+    expect(char.stats.stats.strength).toBe(base + 3);
+
+    unequipItemToInventory(char, 'mainhand');
+    expect(char.stats.stats.strength).toBe(base);
+  });
 });


### PR DESCRIPTION
## Summary
- extend item model with stat bonus support
- update inventory start items with basic bonuses
- modify equip/unequip logic to apply bonuses to character stats
- test new behaviour in item model tests

## Testing
- `npm test`
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_684428b240f0832bb3ef550bc8f89e25