### PR TITLE
Add equipment persistence and tooltips

### DIFF
--- a/src/components/Character/CharacterEquipmentUI.tsx
+++ b/src/components/Character/CharacterEquipmentUI.tsx
@@ -1,5 +1,8 @@
 // src/components/Character/CharacterEquipmentUI.tsx
+import React from 'react';
 import { type CharacterEquipment, type EquipmentSlot, EQUIPMENT_SLOTS } from '../../gameServer/itemModel';
+import Tooltip from '../Tooltip';
+import ItemTooltipContent from '../ItemTooltipContent';
 
 const SLOT_LABELS: Record<EquipmentSlot, string> = {
   helmet: 'Casque',
@@ -54,7 +57,8 @@ export default function CharacterEquipmentUI({ equipment, onUnequip }: Props) {
       >
         {EQUIPMENT_SLOTS.map((slot) => {
           const item = equipment[slot];
-          return (
+          const content = item ? <ItemTooltipContent item={item} /> : null;
+          const box = (
             <div
               key={slot}
               onClick={() => item && onUnequip(slot)}
@@ -73,11 +77,11 @@ export default function CharacterEquipmentUI({ equipment, onUnequip }: Props) {
                 padding: '2px',
                 cursor: item ? 'pointer' : 'default'
               }}
-              title={item?.name ?? SLOT_LABELS[slot]}
             >
               {item ? item.emoji ?? SLOT_EMOJIS[slot] : SLOT_LABELS[slot]}
             </div>
           );
+          return item ? <Tooltip content={content}>{box}</Tooltip> : box;
         })}
       </div>
     </section>

--- a/src/components/Character/CharacterInventoryUI.tsx
+++ b/src/components/Character/CharacterInventoryUI.tsx
@@ -1,5 +1,8 @@
 // src/components/Character/CharacterInventoryUI.tsx
+import React from 'react';
 import { type CharacterInventory, MAX_INVENTORY_SIZE } from '../../gameServer/itemModel';
+import Tooltip from '../Tooltip';
+import ItemTooltipContent from '../ItemTooltipContent';
 
 type Props = {
   inventory: CharacterInventory;
@@ -28,7 +31,8 @@ export default function CharacterInventoryUI({ inventory, onEquip }: Props) {
       >
         {Array.from({ length: MAX_INVENTORY_SIZE }).map((_, index) => {
           const item = inventory[index];
-          return (
+          const content = item ? <ItemTooltipContent item={item} /> : null;
+          const box = (
             <div
               key={index}
               onClick={() => item && onEquip(index)}
@@ -45,11 +49,11 @@ export default function CharacterInventoryUI({ inventory, onEquip }: Props) {
                 color: '#888',
                 cursor: item ? 'pointer' : 'default'
               }}
-              title={item?.name}
             >
               {item ? item.emoji ?? '❓' : `Slot ${index + 1}`}
             </div>
           );
+          return item ? <Tooltip content={content}>{box}</Tooltip> : box;
         })}
       </div>
     </section>

--- a/src/components/Character/CharacterPanel.tsx
+++ b/src/components/Character/CharacterPanel.tsx
@@ -1,5 +1,5 @@
 // src/components/Character/CharacterPanel.tsx
-import { useState, useEffect } from 'react';
+import React, { useState, useEffect } from 'react';
 import { characterService } from '../../services/characterService';
 import {
   equipItemFromInventory,
@@ -25,6 +25,7 @@ export default function CharacterPanel() {
     const clone = cloneCharacter(character);
     if (equipItemFromInventory(clone, index)) {
       setCharacter(clone);
+      characterService.update(clone);
     }
   };
 
@@ -33,6 +34,7 @@ export default function CharacterPanel() {
     const clone = cloneCharacter(character);
     if (unequipItemToInventory(clone, slot)) {
       setCharacter(clone);
+      characterService.update(clone);
     }
   };
 

--- a/src/components/CharacterList/CharacterStatsDisplay.tsx
+++ b/src/components/CharacterList/CharacterStatsDisplay.tsx
@@ -1,12 +1,6 @@
 import React from 'react';
 import type { CharacterStats } from '../../gameServer/characterModel';
-
-// Format intelligent : fireRes → Fire Res
-function formatStatLabel(key: string): string {
-  return key
-    .replace(/([A-Z])/g, ' $1')
-    .replace(/^./, (c) => c.toUpperCase());
-}
+import { formatStatLabel } from '../../utils/formatStatLabel';
 
 type Props = {
   stats: CharacterStats;

--- a/src/components/ItemTooltipContent.tsx
+++ b/src/components/ItemTooltipContent.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import type { Item, ItemBonuses } from '../gameServer/itemModel';
+import { formatStatLabel } from '../utils/formatStatLabel';
+
+type Props = { item: Item };
+
+function renderBonuses(bonuses: ItemBonuses | undefined) {
+  if (!bonuses) return null;
+  const lines: React.ReactNode[] = [];
+  for (const [sectionKey, sectionValue] of Object.entries(bonuses)) {
+    if (!sectionValue) continue;
+    for (const [statKey, value] of Object.entries(sectionValue)) {
+      lines.push(
+        <div key={sectionKey + statKey}>
+          {formatStatLabel(statKey)} +{value}
+        </div>
+      );
+    }
+  }
+  return lines.length > 0 ? <div style={{ marginTop: 4 }}>{lines}</div> : null;
+}
+
+export default function ItemTooltipContent({ item }: Props) {
+  return (
+    <div>
+      <strong>{item.name}</strong>
+      {renderBonuses(item.bonuses)}
+    </div>
+  );
+}

--- a/src/components/Tooltip.tsx
+++ b/src/components/Tooltip.tsx
@@ -1,0 +1,40 @@
+import React, { useState } from 'react';
+
+export type TooltipProps = {
+  content: React.ReactNode;
+  children: React.ReactNode;
+};
+
+export default function Tooltip({ content, children }: TooltipProps) {
+  const [visible, setVisible] = useState(false);
+  return (
+    <span
+      style={{ position: 'relative', display: 'inline-block' }}
+      onMouseEnter={() => setVisible(true)}
+      onMouseLeave={() => setVisible(false)}
+    >
+      {children}
+      {visible && (
+        <div
+          style={{
+            position: 'absolute',
+            top: '100%',
+            left: '50%',
+            transform: 'translateX(-50%)',
+            background: '#333',
+            color: '#fff',
+            padding: '0.25rem 0.5rem',
+            borderRadius: 4,
+            whiteSpace: 'nowrap',
+            fontSize: '0.75rem',
+            zIndex: 10,
+            pointerEvents: 'none',
+            marginTop: 4
+          }}
+        >
+          {content}
+        </div>
+      )}
+    </span>
+  );
+}

--- a/src/gameServer/characterModel.ts
+++ b/src/gameServer/characterModel.ts
@@ -1,10 +1,5 @@
 // src/gameServer/characterModel.ts
-import {
-  CharacterEquipment,
-  CharacterInventory,
-  createEmptyEquipment,
-  createEmptyInventory
-} from './itemModel';
+import { CharacterEquipment, CharacterInventory } from './itemModel';
 
 export type CharacterStats = {
   core: {

--- a/src/gameServer/itemModel.test.ts
+++ b/src/gameServer/itemModel.test.ts
@@ -1,6 +1,5 @@
 import { createDefaultStats } from './characterModel';
 import {
-  EQUIPMENT_SLOTS,
   Item,
   createEmptyEquipment,
   createEmptyInventory,

--- a/src/gameServer/itemModel.ts
+++ b/src/gameServer/itemModel.ts
@@ -97,8 +97,10 @@ function applyItemBonuses(stats: CharacterStats, item: Item, factor: 1 | -1) {
     const targetSection = stats[sectionKey as keyof CharacterStats] as Record<string, number>;
     if (!bonusSection || !targetSection) continue;
     for (const statKey of Object.keys(bonusSection) as string[]) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const value = (bonusSection as any)[statKey];
       if (typeof value === 'number') {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         (targetSection as any)[statKey] += factor * value;
       }
     }

--- a/src/pages/GamePage.tsx
+++ b/src/pages/GamePage.tsx
@@ -6,6 +6,7 @@ import CharacterStatsUI from '../components/Character/CharacterStatsUI';
 import CharacterEquipmentUI from '../components/Character/CharacterEquipmentUI';
 import CombatZoneSelector from '../components/Combat/CombatZoneSelector';
 import CharacterInventoryUI from '../components/Character/CharacterInventoryUI';
+import { characterService } from '../services/characterService';
 import {
   equipItemFromInventory,
   unequipItemToInventory,
@@ -21,7 +22,7 @@ export default function GamePage() {
   if (!charData) {
     return (
       <p style={{ color: '#f66', padding: '1rem' }}>
-        ❌ Aucun personnage sélectionné. Retournez à l'accueil.
+        ❌ Aucun personnage sélectionné. Retournez à l&apos;accueil.
       </p>
     );
   }
@@ -31,6 +32,7 @@ export default function GamePage() {
     const clone = cloneCharacter(charData);
     if (equipItemFromInventory(clone, index)) {
       setCharData(clone);
+      characterService.update(clone);
     }
   };
 
@@ -39,6 +41,7 @@ export default function GamePage() {
     const clone = cloneCharacter(charData);
     if (unequipItemToInventory(clone, slot)) {
       setCharData(clone);
+      characterService.update(clone);
     }
   };
 

--- a/src/services/characterService.test.ts
+++ b/src/services/characterService.test.ts
@@ -16,6 +16,7 @@ describe('characterService', () => {
         offensive: { hitChance: 90, criticalChance: 10, criticalDamage: 120 }
         // defensive branch intentionally missing
       }
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } as any;
     localStorage.setItem('characters', JSON.stringify([partialCharacter]));
 

--- a/src/services/characterService.ts
+++ b/src/services/characterService.ts
@@ -19,9 +19,11 @@ function simulateDelay<T>(data: T, ms = 50): Promise<T> {
 
 // 🔁 Fonction utilitaire récursive pour migrer une branche de stats
 function migrateBranch<T extends object>(branch: T, fallback: T): T {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const migrated: any = {};
   for (const key in fallback) {
     const fallbackValue = fallback[key];
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const legacyValue = (branch as any)?.[key];
 
     // Si c’est un objet (branche profonde), on migre récursivement
@@ -37,6 +39,7 @@ function migrateBranch<T extends object>(branch: T, fallback: T): T {
 // 🔁 Migration complète des stats avec fallback intelligent
 function migrateCharacter(char: Character): Character {
   const defaultStats = createDefaultStats();
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const legacyStats = char.stats as any;
 
   const migratedStats: CharacterStats = migrateBranch(legacyStats, defaultStats);
@@ -107,6 +110,16 @@ export const characterService = {
       localStorage.removeItem(ACTIVE_KEY);
     }
 
+    return simulateDelay(undefined);
+  },
+
+  async update(character: Character): Promise<void> {
+    const all = await characterService.getAll();
+    const idx = all.findIndex((c) => c.id === character.id);
+    if (idx !== -1) {
+      all[idx] = character;
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(all));
+    }
     return simulateDelay(undefined);
   },
 

--- a/src/utils/formatStatLabel.ts
+++ b/src/utils/formatStatLabel.ts
@@ -1,0 +1,3 @@
+export function formatStatLabel(key: string): string {
+  return key.replace(/([A-Z])/g, ' $1').replace(/^./, (c) => c.toUpperCase());
+}


### PR DESCRIPTION
## Summary
- add custom Tooltip and ItemTooltipContent components
- show item info on equipment and inventory hover
- persist equipment/inventory through new `characterService.update`
- fix ESLint issues
- use shared `formatStatLabel` util

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68442ba26060832b9d0af736fdb0a862