### PR TITLE
Fix key prop warning

### DIFF
--- a/src/components/Character/CharacterEquipmentUI.tsx
+++ b/src/components/Character/CharacterEquipmentUI.tsx
@@ -60,7 +60,6 @@ export default function CharacterEquipmentUI({ equipment, onUnequip }: Props) {
           const content = item ? <ItemTooltipContent item={item} /> : null;
           const box = (
             <div
-              key={slot}
               onClick={() => item && onUnequip(slot)}
               style={{
                 width: 48,
@@ -81,7 +80,13 @@ export default function CharacterEquipmentUI({ equipment, onUnequip }: Props) {
               {item ? item.emoji ?? SLOT_EMOJIS[slot] : SLOT_LABELS[slot]}
             </div>
           );
-          return item ? <Tooltip content={content}>{box}</Tooltip> : box;
+          return item ? (
+            <Tooltip key={slot} content={content}>
+              {box}
+            </Tooltip>
+          ) : (
+            React.cloneElement(box, { key: slot })
+          );
         })}
       </div>
     </section>


### PR DESCRIPTION
## Summary
- fix missing key prop when rendering Tooltip around equipment box

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: eslint config parser missing)*
- `npm run build` *(fails: vite not found)*
- `npx tsc -p tsconfig.json` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684434602d2c832bbd9ae3e004dd447e