### PR TITLE
Fix paths and add missing UI components

### DIFF
--- a/src/components/Character/CharacterEquipmentUI.tsx
+++ b/src/components/Character/CharacterEquipmentUI.tsx
@@ -1,6 +1,6 @@
 // src/components/Character/CharacterEquipmentUI.tsx
 import React from 'react';
-import { type CharacterEquipment, type EquipmentSlot, EQUIPMENT_SLOTS } from '../models/itemModel';
+import { type CharacterEquipment, type EquipmentSlot, EQUIPMENT_SLOTS } from '../../models/itemModel';
 import Tooltip from '../Tooltip';
 import ItemTooltipContent from '../ItemTooltipContent';
 

--- a/src/components/Character/CharacterInventoryUI.tsx
+++ b/src/components/Character/CharacterInventoryUI.tsx
@@ -1,6 +1,6 @@
 // src/components/Character/CharacterInventoryUI.tsx
 import React from 'react';
-import { type CharacterInventory, MAX_INVENTORY_SIZE } from '../models/itemModel';
+import { type CharacterInventory, MAX_INVENTORY_SIZE } from '../../models/itemModel';
 import Tooltip from '../Tooltip';
 import ItemTooltipContent from '../ItemTooltipContent';
 

--- a/src/components/Character/CharacterPanel.tsx
+++ b/src/components/Character/CharacterPanel.tsx
@@ -5,9 +5,9 @@ import {
   equipItemFromInventory,
   unequipItemToInventory,
   type EquipmentSlot
-} from '../models/itemModel';
-import type { Character } from '../models/characterModel';
-import { cloneCharacter } from '../models/characterModel';
+} from '../../models/itemModel';
+import type { Character } from '../../models/characterModel';
+import { cloneCharacter } from '../../models/characterModel';
 import CharacterInventoryUI from './CharacterInventoryUI';
 import CharacterEquipmentUI from './CharacterEquipmentUI';
 

--- a/src/components/Character/CharacterStatsUI.tsx
+++ b/src/components/Character/CharacterStatsUI.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import type { Character } from '../models/characterModel';
+import type { Character } from '../../models/characterModel';
 import CharacterStatsDisplay from '../CharacterList/CharacterStatsDisplay';
 
 type Props = {

--- a/src/components/CharacterList/CharacterList.tsx
+++ b/src/components/CharacterList/CharacterList.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import type { Character } from '../../models/characterModel';
+
+export type CharacterListProps = {
+  characters: Character[];
+  activeId: number | null;
+  onSelect: (id: number) => void;
+  onDelete: (id: number) => void;
+};
+
+export default function CharacterList({ characters, activeId, onSelect, onDelete }: CharacterListProps) {
+  return (
+    <div>
+      {characters.map((char) => (
+        <div
+          key={char.id}
+          style={{
+            border: char.id === activeId ? '2px solid #4caf50' : '1px solid #ccc',
+            padding: '0.5rem',
+            marginBottom: '0.5rem',
+          }}
+        >
+          <strong>{char.name}</strong>
+          <div style={{ float: 'right' }}>
+            <button onClick={() => onSelect(char.id)} style={{ marginRight: '0.5rem' }}>
+              Sélectionner
+            </button>
+            <button onClick={() => onDelete(char.id)}>Supprimer</button>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/components/CharacterList/CharacterStatsDisplay.tsx
+++ b/src/components/CharacterList/CharacterStatsDisplay.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import type { CharacterStats } from '../../models/characterModel';
+import { formatStatLabel } from '../../utils/formatStatLabel';
+
+export type CharacterStatsDisplayProps = {
+  stats: CharacterStats;
+};
+
+export default function CharacterStatsDisplay({ stats }: CharacterStatsDisplayProps) {
+  return (
+    <div>
+      {Object.entries(stats).map(([section, values]) => (
+        values ? (
+          <div key={section}>
+            <strong>{formatStatLabel(section)}</strong>
+            <ul>
+              {Object.entries(values).map(([k, v]) => (
+                <li key={k}>
+                  {formatStatLabel(k)}: {v as number}
+                </li>
+              ))}
+            </ul>
+          </div>
+        ) : null
+      ))}
+    </div>
+  );
+}

--- a/src/components/Combat/CombatZoneSelector.tsx
+++ b/src/components/Combat/CombatZoneSelector.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+export default function CombatZoneSelector() {
+  return (
+    <div style={{ padding: '1rem', border: '1px solid #0f0', borderRadius: 4 }}>
+      <p>Zone de combat à venir...</p>
+    </div>
+  );
+}

--- a/src/components/ItemTooltipContent.tsx
+++ b/src/components/ItemTooltipContent.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import type { Item } from '../models/itemModel';
+import { formatStatLabel } from '../utils/formatStatLabel';
+
+export type ItemTooltipContentProps = {
+  item: Item;
+};
+
+export default function ItemTooltipContent({ item }: ItemTooltipContentProps) {
+  return (
+    <div>
+      <strong>{item.name}</strong>
+      {item.bonuses && (
+        <ul>
+          {Object.entries(item.bonuses).map(([section, values]) => (
+            <li key={section}>
+              {formatStatLabel(section)}
+              <ul>
+                {Object.entries(values || {}).map(([k, v]) => (
+                  <li key={k}>
+                    {formatStatLabel(k)}: {v as number}
+                  </li>
+                ))}
+              </ul>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/src/components/Tooltip.tsx
+++ b/src/components/Tooltip.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+
+export type TooltipProps = {
+  content: React.ReactNode;
+  children: React.ReactNode;
+};
+
+export default function Tooltip({ content, children }: TooltipProps) {
+  const title = typeof content === 'string' ? content : undefined;
+  return (
+    <span title={title} style={{ position: 'relative' }}>
+      {children}
+    </span>
+  );
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4,7 +4,7 @@ import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import App from './App';
 import CharacterSelectPage from './pages/CharacterSelectPage';
 import GamePage from './pages/GamePage';
-import './css/globals.css';
+import './styles/globals.css';
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>

--- a/src/pages/CharacterSelectPage.tsx
+++ b/src/pages/CharacterSelectPage.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { characterService } from '../services/characterService';
-import type { Character } from '../gameServer/characterModel';
+import type { Character } from '../models/characterModel';
 import CharacterList from '../components/CharacterList/CharacterList';
 import { useNavigate } from 'react-router-dom';
 

--- a/src/pages/GamePage.tsx
+++ b/src/pages/GamePage.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { useLocation } from 'react-router-dom';
-import type { Character } from '../gameServer/characterModel';
-import { cloneCharacter } from '../gameServer/characterModel';
+import type { Character } from '../models/characterModel';
+import { cloneCharacter } from '../models/characterModel';
 import CharacterStatsUI from '../components/Character/CharacterStatsUI';
 import CharacterEquipmentUI from '../components/Character/CharacterEquipmentUI';
 import CombatZoneSelector from '../components/Combat/CombatZoneSelector';
@@ -11,7 +11,7 @@ import {
   equipItemFromInventory,
   unequipItemToInventory,
   type EquipmentSlot
-} from '../gameServer/itemModel';
+} from '../models/itemModel';
 
 export default function GamePage() {
   const location = useLocation();

--- a/src/services/characterService.test.ts
+++ b/src/services/characterService.test.ts
@@ -1,5 +1,5 @@
 import { characterService } from './characterService';
-import { createDefaultStats } from '../gameServer/characterModel';
+import { createDefaultStats } from '../models/characterModel';
 
 describe('characterService', () => {
   beforeEach(() => {

--- a/src/services/characterService.ts
+++ b/src/services/characterService.ts
@@ -3,12 +3,12 @@ import {
   Character,
   CharacterStats,
   createDefaultStats
-} from '../gameServer/characterModel';
+} from '../models/characterModel';
 import {
   createEmptyEquipment,
   createEmptyInventory,
   createDefaultInventory
-} from '../gameServer/itemModel';
+} from '../models/itemModel';
 
 const STORAGE_KEY = 'characters';
 const ACTIVE_KEY = 'activeCharacterId';


### PR DESCRIPTION
## Summary
- fix broken relative imports across the project
- add placeholder UI components (tooltip, item tooltip, character list, stats display, combat zone selector)
- adjust main stylesheet path
- update tests accordingly

## Testing
- `npm test`
- `npm run lint`
- `npx tsc --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_6844c84f070c832b98e7455fd64ae695